### PR TITLE
feat: add basic todo app HTML structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo App</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            background-color: #f5f5f5;
+            color: #333;
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            padding: 40px 16px;
+        }
+
+        .container {
+            width: 100%;
+            max-width: 500px;
+        }
+
+        h1 {
+            text-align: center;
+            margin-bottom: 24px;
+            font-weight: 600;
+            font-size: 1.75rem;
+            color: #1a1a1a;
+        }
+
+        .card {
+            background: #fff;
+            border-radius: 12px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+            padding: 24px;
+        }
+
+        .input-row {
+            display: flex;
+            gap: 8px;
+        }
+
+        #todo-input {
+            flex: 1;
+            padding: 10px 14px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            font-size: 1rem;
+            outline: none;
+            transition: border-color 0.2s;
+        }
+
+        #todo-input:focus {
+            border-color: #4a90d9;
+        }
+
+        #add-btn {
+            padding: 10px 20px;
+            background-color: #4a90d9;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+
+        #add-btn:hover {
+            background-color: #3a7bc8;
+        }
+
+        #todo-list {
+            list-style: none;
+            margin-top: 16px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Todo App</h1>
+        <div class="card">
+            <div class="input-row">
+                <input type="text" id="todo-input" placeholder="Add a new todo..." />
+                <button id="add-btn">Add</button>
+            </div>
+            <ul id="todo-list"></ul>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Created `index.html` with a clean, modern todo app layout
- Centered card-style design (max-width 500px) with input field, Add button, and empty `<ul>` container
- Mobile-friendly with viewport meta tag and sans-serif typography

## Verification with agent-browser
- Opened `http://localhost:3456` and confirmed the page renders correctly
- Took screenshot verifying centered card layout with styled input and button
- Ran `agent-browser snapshot -i` confirming interactive elements: textbox "Add a new todo..." and button "Add"

## Test plan
- [x] Opening index.html shows a styled todo input form
- [x] Input field and button are visible and properly styled
- [x] Page is centered and responsive

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)