### PR TITLE
feat: add JavaScript to create and delete todos

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,38 @@
             list-style: none;
             margin-top: 16px;
         }
+
+        .todo-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 14px;
+            border-bottom: 1px solid #eee;
+        }
+
+        .todo-item:last-child {
+            border-bottom: none;
+        }
+
+        .todo-item span {
+            flex: 1;
+            font-size: 1rem;
+        }
+
+        .delete-btn {
+            padding: 4px 12px;
+            background-color: #e74c3c;
+            color: #fff;
+            border: none;
+            border-radius: 6px;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: background-color 0.2s;
+        }
+
+        .delete-btn:hover {
+            background-color: #c0392b;
+        }
     </style>
 </head>
 <body>
@@ -92,5 +124,38 @@
             <ul id="todo-list"></ul>
         </div>
     </div>
+    <script>
+        const input = document.getElementById('todo-input');
+        const addBtn = document.getElementById('add-btn');
+        const todoList = document.getElementById('todo-list');
+
+        function addTodo() {
+            const text = input.value.trim();
+            if (!text) return;
+
+            const li = document.createElement('li');
+            li.className = 'todo-item';
+
+            const span = document.createElement('span');
+            span.textContent = text;
+
+            const deleteBtn = document.createElement('button');
+            deleteBtn.className = 'delete-btn';
+            deleteBtn.textContent = 'Delete';
+            deleteBtn.addEventListener('click', () => li.remove());
+
+            li.appendChild(span);
+            li.appendChild(deleteBtn);
+            todoList.appendChild(li);
+
+            input.value = '';
+            input.focus();
+        }
+
+        addBtn.addEventListener('click', addTodo);
+        input.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter') addTodo();
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Added inline JavaScript to handle creating and deleting todo items
- Added CSS styles for todo items and delete buttons
- Clicking "Add" or pressing Enter creates a new todo with a Delete button
- Empty/whitespace-only input is rejected
- Clicking Delete removes the todo from the list

Closes #2

## Verification with agent-browser
- Opened the app at localhost:3456 and confirmed it loads correctly
- Filled input with "Buy groceries" and clicked Add — todo appeared with Delete button
- Filled input with "Walk the dog" and pressed Enter — second todo added
- Submitted whitespace-only input — correctly rejected (no new todo)
- Clicked Delete on first todo — it was removed, second todo remained
- Took a screenshot confirming correct visual layout

## Test plan
- [ ] Type a todo and click Add — todo appears in the list
- [ ] Type a todo and press Enter — todo appears in the list
- [ ] Submit empty or whitespace input — nothing is added
- [ ] Click Delete on a todo — it is removed from the list
- [ ] Input field clears and refocuses after adding a todo

🤖 Generated with [Claude Code](https://claude.com/claude-code)